### PR TITLE
Use ssh as default option if no subcommand is called

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -114,6 +114,7 @@ func postRun() {
 			fmt.Printf("Failed to flush logfile: %v", err)
 		}
 		logFile.Close()
+		logFile = nil
 	}
 }
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -36,8 +36,16 @@ func NewRootCommand() *cobra.Command {
 		Use:              version.Name,
 		Short:            version.Name + " allows using pageant inside WSL2 Distros as ssh-agent.",
 		PersistentPreRun: preRun,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			UnknownFlags: true,
+		},
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Printf(cmd.UsageString())
+			os.Args = append([]string{os.Args[0], ssh.CommandName}, os.Args[1:]...)
+			cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {}
+			err := cmd.Execute()
+			if err != nil {
+				exitError(cmd, err)
+			}
 		},
 	}
 

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/heathcliff26/wsl2-ssh-pageant/pkg/version"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRootCommand(t *testing.T) {
+	cmd := NewRootCommand()
+
+	assert.Equal(t, version.Name, cmd.Use)
+}
+
+func TestSetupAndCleanup(t *testing.T) {
+	cmd := NewRootCommand()
+
+	_ = cmd.ParseFlags([]string{})
+
+	preRun(cmd, []string{})
+
+	assert := assert.New(t)
+
+	assert.NotNil(logFile)
+	assert.Equal(DefaultLogLevel, strings.ToLower(logLevel.Level().String()))
+
+	postRun()
+
+	assert.Nil(logFile)
+
+	err := os.Remove(DefaultLogFile)
+	if err != nil {
+		t.Fatalf("Failed to remove logfile: %v", err)
+	}
+}

--- a/pkg/ssh/cmd.go
+++ b/pkg/ssh/cmd.go
@@ -8,13 +8,15 @@ import (
 )
 
 const (
+	CommandName = "ssh"
+
 	flagNamePipe = "pipe"
 )
 
 func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "ssh",
-		Short: "Connect Pageant to unix socket via socat",
+		Use:   CommandName,
+		Short: "Connect Pageant to unix socket via socat. (Default)",
 		Run: func(cmd *cobra.Command, args []string) {
 			pipe, err := cmd.Flags().GetString(flagNamePipe)
 			if err != nil {


### PR DESCRIPTION
This re-enables the default behaviour of simply calling wsl2-ssh-pageant.exe

Add basic tests for root command