### PR TITLE
go.mod: Update go version to 1.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/heathcliff26/wsl2-ssh-pageant
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/Microsoft/go-winio v0.6.2


### PR DESCRIPTION
According to CodeQL:
As of Go 1.21, toolchain versions must use the 1.N.P syntax.