### PR TITLE
Makefile: Add fmt and validate commands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,12 @@ jobs:
     with:
       os: windows-latest
 
+  validate:
+    uses: heathcliff26/ci/.github/workflows/golang-build.yaml@main
+    with:
+      cache: false
+      cmd: "make validate"
+
   build:
     uses: heathcliff26/ci/.github/workflows/golang-build.yaml@main
     needs:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ test:
 lint:
 	golangci-lint run -v
 
+fmt:
+	gofmt -s -w ./cmd ./pkg
+
+validate:
+	hack/validate.sh
+
 coverprofile:
 	hack/coverprofile.sh
 
@@ -25,6 +31,8 @@ listen: build
 	build \
 	test \
 	lint \
+	fmt \
+	validate \
 	coverprofile \
 	dependencies \
 	listen \

--- a/hack/validate.sh
+++ b/hack/validate.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+echo "Check if source code is formatted"
+make fmt
+rc=0
+git update-index --refresh && git diff-index --quiet HEAD -- || rc=1
+if [ $rc -ne 0 ]; then
+    echo "FATAL: Need to run \"make fmt\""
+    exit 1
+fi


### PR DESCRIPTION
Add a command to format the go code.
Add a command to validate that the workspace is clean.

Ensure code is always properly formatted by adding the validate step to ci.