### PR TITLE
version: Use the version from build info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/heathcliff26/wsl2-ssh-pageant
 
-go 1.22.0
+go 1.24.0
 
 require (
 	github.com/Microsoft/go-winio v0.6.2

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -11,11 +11,6 @@ GOARCH="${GOARCH:-$(go env GOARCH)}"
 
 GO_LD_FLAGS="${GO_LD_FLAGS:-"-s"}"
 
-if [ "${RELEASE_VERSION}" != "" ]; then
-    echo "Building release version ${RELEASE_VERSION}"
-    GO_LD_FLAGS+=" -X github.com/heathcliff26/wsl2-ssh-pageant/pkg/version.version=${RELEASE_VERSION}"
-fi
-
 output_name="${bin_dir}/wsl2-ssh-pageant.exe"
 if [ "${1}" != "" ]; then
     output_name="${bin_dir}/${1}.exe"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,6 @@
 package version
 
 import (
-	"fmt"
 	"runtime"
 	"runtime/debug"
 
@@ -10,14 +9,13 @@ import (
 
 const Name = "wsl2-ssh-pageant"
 
-var version = "devel"
-
+// Create a new version command with the given app name
 func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print version information and exit",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Print(Version())
+			cmd.Print(VersionInfoString())
 		},
 	}
 	// Override to prevent parent function from running
@@ -26,7 +24,14 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
+// Return the version string
 func Version() string {
+	buildinfo, _ := debug.ReadBuildInfo()
+	return buildinfo.Main.Version
+}
+
+// Return a formated string containing the version, git commit and go version the app was compiled with.
+func VersionInfoString() string {
 	var commit string
 	buildinfo, _ := debug.ReadBuildInfo()
 	for _, item := range buildinfo.Settings {
@@ -42,7 +47,7 @@ func Version() string {
 	}
 
 	result := Name + ":\n"
-	result += "    Version: " + version + "\n"
+	result += "    Version: " + buildinfo.Main.Version + "\n"
 	result += "    Commit:  " + commit + "\n"
 	result += "    Go:      " + runtime.Version() + "\n"
 

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"testing"
 
@@ -18,17 +19,27 @@ func TestNewVersionCommand(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
-	result := Version()
+	assert := assert.New(t)
+
+	buildinfo, _ := debug.ReadBuildInfo()
+
+	assert.Equal(buildinfo.Main.Version, Version(), "Version should return the version from build info")
+}
+
+func TestVersionInfoString(t *testing.T) {
+	result := VersionInfoString()
 
 	lines := strings.Split(result, "\n")
 
 	assert := assert.New(t)
 
+	buildinfo, _ := debug.ReadBuildInfo()
+
 	if !assert.Equal(5, len(lines), "Should have enough lines") {
 		t.FailNow()
 	}
 	assert.Contains(lines[0], Name)
-	assert.Contains(lines[1], version)
+	assert.Contains(lines[1], buildinfo.Main.Version)
 
 	commit := strings.Split(lines[2], ":")
 	assert.NotEmpty(strings.TrimSpace(commit[1]))


### PR DESCRIPTION
With golang 1.24, the version derived from tag is now embedded by default. Use it instead, as it is better and easier than stamping it manually during build.
Require golang 1.24.