### PR TITLE
Fix code alerts found by gosec

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -84,6 +84,7 @@ func preRun(cmd *cobra.Command, args []string) {
 	if err != nil {
 		exitError(cmd, err)
 	}
+	// #nosec G302,G304: Local users can freely decide the log file location. Final file permissions should be decided by umask.
 	f, err := os.OpenFile(logFilePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
 		exitError(cmd, err)
@@ -113,7 +114,10 @@ func postRun() {
 		if err != nil {
 			fmt.Printf("Failed to flush logfile: %v", err)
 		}
-		logFile.Close()
+		err = logFile.Close()
+		if err != nil {
+			fmt.Printf("Failed to close logfile: %v", err)
+		}
 		logFile = nil
 	}
 }

--- a/pkg/gpg/gpg.go
+++ b/pkg/gpg/gpg.go
@@ -14,6 +14,7 @@ func handleGPG(path string) {
 	var port int
 	var nonce [16]byte
 
+	// #nosec G304: It is the users responsibility to ensure that the gpg socket is secure.
 	file, err := os.Open(path)
 	if err != nil {
 		slog.Error("Failed to open gpg directory", "err", err)

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -38,6 +38,7 @@ type copyDataStruct struct {
 	lpData uintptr
 }
 
+// #nosec G103: Using unsafe here to write to shared memory
 func queryPageant(buf []byte) (result []byte, err error) {
 	if len(buf) > agentMaxMessageLength {
 		err = NewErrMessageLength(len(buf))


### PR DESCRIPTION
Fix missing error returns.
Document use of unsafe pointers for the whole function.
Add #nosec comments with justification where appropiate.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>