### PR TITLE
CI: Fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
     with:
       release_version: "${{ inputs.version }}"
 


### PR DESCRIPTION
Update the release workflow to account for gosec action.